### PR TITLE
Add labeler config required by the Labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+# Configuration for the Labeler workflow (.github/workflows/label.yml)
+# Applies labels to pull requests based on changed paths.
+
+java:
+  - 'src/**/*.java'
+
+build:
+  - 'pom.xml'
+  - 'dependency-reduced-pom.xml'
+
+ci:
+  - '.github/workflows/**'
+
+documentation:
+  - '**/*.md'


### PR DESCRIPTION
## Summary

The `Labeler` workflow runs `actions/labeler@v4` on every pull request, but the repo has no `.github/labeler.yml`, so the `label` check fails with `HttpError: Not Found` on every PR (e.g. the run on #14).

This adds a minimal path-based config (java / build / ci / documentation). Note the labeler fetches its config from the default branch, so the check only goes green for PRs opened after this merges.

This commit was pushed while #14 was being merged and just missed it, hence the separate PR.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_